### PR TITLE
fix minor bug that causes toolchain not found error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go-gin-crud
 
-go 1.24
+go 1.24.2
 
 require (
 	github.com/gin-gonic/gin v1.10.0


### PR DESCRIPTION
Пробовал запустить так, появилась ошибка toolchain not available.
На основе рекомендаций с [этого треда](https://stackoverflow.com/questions/78519711/toolchain-not-available-error-prevents-me-from-using-any-go-commands) на Stack Overflow предлагаю такую правку в go.mod